### PR TITLE
Feature/updatecheck

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -4,3 +4,4 @@
 fixtures:
   forge_modules:
     stdlib: "puppetlabs/stdlib"
+    registry: "puppetlabs/registry"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## Release 0.2.0
+
+**Features**
+- Added: able to set the notification policy for Powershell 7 Update checks.
+- Added: added metadata.json tags for better visibility of what this module references.
+
+**Bugfixes**
+- Fix: powershell7::install exec kept running due to the creates attribute sourcing the wrong file.
+- Fix: installation source URLs now allow HTTP as well has HTTPS locations.
+- Fix: supported version of puppet was lowered to `6.0.0` as it works across all Puppet 6 versions.
+
 ## Release 0.1.0
 
 **Features**

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -4,3 +4,4 @@ powershell7::add_file_context_menu_runpowershell: 1
 powershell7::enable_psremoting: 1
 powershell7::register_manifest: 1
 powershell7::release_type: 'stable'
+powershell7::powershell_updatecheck: 'Default'

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,0 +1,9 @@
+# @summary Configuration options for Powershell 7 once installed
+#
+# Once Powershell 7 has been installed there are various configurations which
+# should be available to customise the behaviour of how Powershell 7 behaves
+#
+# @api private
+#
+class powershell7::config {
+}

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -6,4 +6,9 @@
 # @api private
 #
 class powershell7::config {
+  registry_value { 'HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment\POWERSHELL_UPDATECHECK':
+    ensure => present,
+    type   => string,
+    data   => 'Default',
+  }
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -9,6 +9,6 @@ class powershell7::config {
   registry_value { 'HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment\POWERSHELL_UPDATECHECK':
     ensure => present,
     type   => string,
-    data   => 'Default',
+    data   => $powershell7::powershell_updatecheck,
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,6 +29,7 @@
 #   Enables PS Remoting during installation. Defaults to 1
 # @param register_manifest
 #   Enables the Windows Event Logging Manifest. Defaults to 1
+# @param powershell_updatecheck Sets the update notification policy to alert users to the availability of updates. Defaults to 'Default'
 #
 # @example
 #   include powershell7
@@ -45,6 +46,7 @@ class powershell7 (
   Integer[0,1] $add_file_context_menu_runpowershell,
   Integer[0,1] $enable_psremoting,
   Integer[0,1] $register_manifest,
+  ENUM['Off','Default','LTS'] $powershell_updatecheck,
 ) {
   contain powershell7::install
   contain powershell7::config

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,4 +47,8 @@ class powershell7 (
   Integer[0,1] $register_manifest,
 ) {
   contain powershell7::install
+  contain powershell7::config
+
+  Class['::powershell7::install']
+  -> Class['::powershell7::config']
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -40,7 +40,7 @@ class powershell7::install {
 
   exec { 'powershell7-install':
     command => "C:\\Windows\\System32\\msiexec.exe /package ${download_dir}\\${file_name} /quiet ADD_EXPLORER_CONTEXT_MENU_OPENPOWERSHELL=${explorer_context_menu} ADD_FILE_CONTEXT_MENU_RUNPOWERSHELL=${file_context_menu} ENABLE_PSREMOTING=${enable_psremoting} REGISTER_MANIFEST=${register_manifest}", # lint:ignore:140chars
-    creates => 'C:\\Program Files\\PowerShell\\7\\powershell.exe',
+    creates => 'C:\\Program Files\\PowerShell\\7\\pwsh.exe',
     require => File['powershell7-download'],
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -10,6 +10,10 @@
     {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 4.13.1 < 8.0.0"
+    },
+    {
+      "name": "puppetlabs/registry",
+      "version_requirement": ">= 3.0.0 < 5.0.0"
     }
   ],
   "operatingsystem_support": [
@@ -26,7 +30,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.21.0 < 8.0.0"
+      "version_requirement": ">= 6.0.0 < 8.0.0"
     }
   ],
   "pdk-version": "2.0.0",

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -6,6 +6,7 @@ describe 'powershell7::config' do
   on_supported_os.each do |os, os_facts|
     context "on #{os}" do
       let(:facts) { os_facts }
+      let(:pre_condition) { 'include powershell7' }
 
       it { is_expected.to compile }
 
@@ -13,6 +14,7 @@ describe 'powershell7::config' do
         is_expected.to contain_registry_value('HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment\POWERSHELL_UPDATECHECK')
           .with_ensure('present')
           .with_type('string')
+          .with_data('Default')
       end
     end
   end

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -8,6 +8,12 @@ describe 'powershell7::config' do
       let(:facts) { os_facts }
 
       it { is_expected.to compile }
+
+      it do
+        is_expected.to contain_registry_value('HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment\POWERSHELL_UPDATECHECK')
+          .with_ensure('present')
+          .with_type('string')
+      end
     end
   end
 end

--- a/spec/classes/config_spec.rb
+++ b/spec/classes/config_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'powershell7::config' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      let(:facts) { os_facts }
+
+      it { is_expected.to compile }
+    end
+  end
+end

--- a/spec/classes/powershell7_spec.rb
+++ b/spec/classes/powershell7_spec.rb
@@ -13,6 +13,10 @@ describe 'powershell7', type: :class do
         is_expected.to contain_class('powershell7::install')
       end
 
+      it do
+        is_expected.to contain_class('powershell7::config')
+      end
+
       context 'with defaults and release_type => stable' do
         let :params do
           {

--- a/spec/classes/powershell7_spec.rb
+++ b/spec/classes/powershell7_spec.rb
@@ -174,6 +174,45 @@ describe 'powershell7', type: :class do
           )
         end
       end
+
+      context 'with powershell_updatecheck => Default' do
+        let :params do
+          {
+            powershell_updatecheck: 'Default',
+          }
+        end
+
+        it do
+          is_expected.to contain_registry_value('HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment\POWERSHELL_UPDATECHECK')
+            .with_data('Default')
+        end
+      end
+
+      context 'with powershell_updatecheck => Off' do
+        let :params do
+          {
+            powershell_updatecheck: 'Off',
+          }
+        end
+
+        it do
+          is_expected.to contain_registry_value('HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment\POWERSHELL_UPDATECHECK')
+            .with_data('Off')
+        end
+      end
+
+      context 'with powershell_updatecheck => LTS' do
+        let :params do
+          {
+            powershell_updatecheck: 'LTS',
+          }
+        end
+
+        it do
+          is_expected.to contain_registry_value('HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment\POWERSHELL_UPDATECHECK')
+            .with_data('LTS')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
- Added: able to set the notification policy for Powershell 7 Update checks.
- Added: added metadata.json tags for better visibility of what this module references.
- Fix: powershell7::install exec kept running due to the creates attribute sourcing the wrong file.
- Fix: supported version of puppet was lowered to `6.0.0` as it works across all Puppet 6 versions.